### PR TITLE
Do not crash in storeData if the table lacks a primary key

### DIFF
--- a/pending.c
+++ b/pending.c
@@ -432,6 +432,12 @@ storeData(char *cpTableName, HeapTuple tTupleData,
 	/* pplan = SPI_saveplan(pplan); */
 	cpKeyData = packageData(tTupleData, tTupleDesc, tableOid, eKeyUsage);
 
+	if (cpKeyData == NULL)
+	{
+		elog(ERROR, "table lacks primary key");
+		return -1;
+	}
+
 	planData[0] = PointerGetDatum(isKey);
 	planData[1] = PointerGetDatum(cpKeyData);
 	iRetValue = SPI_execp(pplan, planData, NULL, 1);


### PR DESCRIPTION
When we execute the plan to INSERT INTO dbmirror_pending, we pass
NULL to SPI_execp as the third parameter, which indicates the second
parameter - planData - does not contain any NULLs. However, it is
possible for planData[1] to contain NULLs, as it is populated by
calling packageData. packageData has two paths - a successful one,
but also a path that returns NULL if the table lacks a primary key.

In this commit, check whether packageData returns NULL, and if so -
die with an error.
