### PR TITLE
Fix compilation with PostgreSQL v16

### DIFF
--- a/pending.c
+++ b/pending.c
@@ -243,7 +243,6 @@ storePending(char *cpTableName, HeapTuple tBeforeTuple,
 {
 	void	   *vpPlan;
 	int			iResult = 0;
-	HeapTuple	tCurTuple;
 	char		nulls[3] = "   ";
 
 	/* Points the current tuple(before or after) */
@@ -251,9 +250,6 @@ storePending(char *cpTableName, HeapTuple tBeforeTuple,
 	Oid			taPlanArgTypes[3] = {NAMEOID, CHAROID, INT4OID};
 	char	   *cpQueryBase =
 	"INSERT INTO dbmirror_pending (TableName,Op,XID) VALUES ($1,$2,$3)";
-
-
-	tCurTuple = tBeforeTuple ? tBeforeTuple : tAfterTuple;
 
 	vpPlan = SPI_prepare(cpQueryBase, 3, taPlanArgTypes);
 	if (vpPlan == NULL)

--- a/pending.c
+++ b/pending.c
@@ -453,7 +453,7 @@ storeData(char *cpTableName, HeapTuple tTupleData,
 		return -1;
 	}
 
-	planData[0] = PointerGetDatum(isKey);
+	planData[0] = BoolGetDatum(isKey);
 	planData[1] = PointerGetDatum(cpKeyData);
 	iRetValue = SPI_execp(pplan, planData, NULL, 1);
 


### PR DESCRIPTION
Fixes the following compilation error:

```
pending.c: In function ‘storeData’:
pending.c:456:39: error: incompatible type for argument 1 of ‘PointerGetDatum’
  456 |         planData[0] = PointerGetDatum(isKey);
      |                                       ^~~~~
      |                                       |
      |                                       _Bool
In file included from pending.c:33:
/usr/include/postgresql/server/postgres.h:322:29: note: expected ‘const void *’ but argument is of type ‘_Bool’
  322 | PointerGetDatum(const void *X)
      |                 ~~~~~~~~~~~~^
make: *** [<builtin>: pending.o] Error 1
```

Since `isKey` is a bool, I changed `PointerGetDatum` to `BoolGetDatum`.